### PR TITLE
Make RPM build optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,31 @@ DataSqueeze supports two types of compaction
         d. Move files from source to temp location. 
         e. Move files from temp-compacted location to source location specified by the user. 
         
-## Run
-There are two different ways of running Compaction Utility: 
+
+## Requirements
+
+* MacOS or Linux
+* Java 7 or later
+* Maven 3.x (for building)
+* rpmbuild (for building RPMs)
+
+## Building DataSqueeze
+
+DataSqueeze is a standard Maven project. Run the following in the project root folder:
+
+    mvn clean package
+
+The compiled JAR can be found at `dataSqueeze-manager/target/dataSqueeze-manager-{VERSION}.jar`.
+    
+To build an RPM, use the optional Maven profile `-P rpm`:
+
+    mvn clean package -P rpm
+    
+This requires `rpmbuild` to be installed, otherwise an error will occur.
+
+## Running DataSqueeze
+
+There are two different ways of running DataSqueeze: 
 
 1. CLI - 
     

--- a/dataSqueeze-manager/pom.xml
+++ b/dataSqueeze-manager/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>dataSqueeze-manager</artifactId>
 
-    
+
     <properties>
         <rpm.install.dir>/opt/dataSqueeze</rpm.install.dir>
         <directory>${project.basedir}/target</directory>
@@ -118,42 +118,52 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>rpm-maven-plugin</artifactId>
-                <version>2.1.5</version>
-                <executions>
-                    <execution>
-                        <id>attach-rpm</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>attached-rpm</goal>
-                        </goals>
-                        <configuration>
-                            <description>${project.description}</description>
-                            <group>Applications/Engineering</group>
-                            <targetOS>Linux</targetOS>
-                            <targetVendor>redhat</targetVendor>
-                            <defaultUsername>${rpm.install.user}</defaultUsername>
-                            <defaultGroupname>${rpm.install.group}</defaultGroupname>
-                            <defaultDirmode>775</defaultDirmode>
-                            <defaultFilemode>644</defaultFilemode>
-                            <mappings>
-                                <mapping>
-                                    <directory>${rpm.install.dir}/lib</directory>
-                                    <sources>
-                                        <source>
-                                            <location>${project.build.directory}/dataSqueeze-manager-${project.version}.jar
-                                            </location>
-                                            <destination>dataSqueeze-manager.jar</destination>
-                                        </source>
-                                    </sources>
-                                </mapping>
-                            </mappings>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>rpm-maven-plugin</artifactId>
+                        <version>2.1.5</version>
+                        <executions>
+                            <execution>
+                                <id>attach-rpm</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attached-rpm</goal>
+                                </goals>
+                                <configuration>
+                                    <description>${project.description}</description>
+                                    <group>Applications/Engineering</group>
+                                    <targetOS>Linux</targetOS>
+                                    <targetVendor>redhat</targetVendor>
+                                    <defaultUsername>${rpm.install.user}</defaultUsername>
+                                    <defaultGroupname>${rpm.install.group}</defaultGroupname>
+                                    <defaultDirmode>775</defaultDirmode>
+                                    <defaultFilemode>644</defaultFilemode>
+                                    <mappings>
+                                        <mapping>
+                                            <directory>${rpm.install.dir}/lib</directory>
+                                            <sources>
+                                                <source>
+                                                    <location>
+                                                        ${project.build.directory}/dataSqueeze-manager-${project.version}.jar
+                                                    </location>
+                                                    <destination>dataSqueeze-manager.jar</destination>
+                                                </source>
+                                            </sources>
+                                        </mapping>
+                                    </mappings>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Created a Maven profile "rpm" that must be enabled using -P rpm.  This allows DataSqueeze to be built on systems without rpmbuild installed.

Updated the README with building instructions, including those for the RPM.